### PR TITLE
Edit labels button interface and functionality fixed

### DIFF
--- a/GUI/app.py
+++ b/GUI/app.py
@@ -27,7 +27,7 @@ class Application(Frame):
 		self.checkButtons = [IntVar(), IntVar()]
 		self.csv_path, self.CLASS_NAME = '', ''
 		self.mkdn2 = Markdown()
-		self.labelList, self.labelOptions = [], []
+		self.labelList, self.tagsList,self.labelOptions = [], [],[]
 
 	def configureStyles(self):
 		self.Program_Style = ttk.Style()

--- a/GUI/interface.py
+++ b/GUI/interface.py
@@ -165,8 +165,11 @@ def generateTestTab(self):
 
 	# ========== Creating an options menu for each of the labels ===========
 	self.labelOptions = []
-	for label in self.labelList:
-		self.labelOptions.append(label.strip())
+	if self.CLASS_NAME == '':
+		self.labelOptions.append('')      
+	else:
+		for label in self.labelList:
+			self.labelOptions.append(label.strip())
 
 	self.labelOptionVar = StringVar(self.frame_test)
 	self.labelOptionVar.set(self.labelOptions[0])
@@ -182,6 +185,7 @@ def generateTestTab(self):
 def generateBuildTab(self):
 	# Create a button to open a smaller window for label editing.
 	self.editLabelButton = Button(self.frame_build, text='Edit Labels', command=lambda: openLabelWindow(self))
+	self.editLabelButton.config(state=DISABLED)
 	self.editLabelButton.place(relx=0.80, rely=0.10, width=150, height=25)
 
 	# Creates a label for showing the processor type used for the NN.

--- a/GUI/methods.py
+++ b/GUI/methods.py
@@ -1,4 +1,4 @@
-import os, sys, csv, platform, predictor, builder, torch, json
+import os, os.path, time, sys, csv, platform, predictor, builder, torch, json
 
 from matplotlib.backends.backend_tkagg import (FigureCanvasTkAgg, NavigationToolbar2Tk) # For showing plots in Tk
 from tkinter import ttk, scrolledtext, filedialog, simpledialog, messagebox # For Tk submodules
@@ -7,6 +7,7 @@ from PIL import ImageTk, Image as PILImage # For showing images.
 from fuzzysearch import find_near_matches # For searching.
 from matplotlib.figure import Figure # For more MPL.
 from tkhtmlview import HTMLLabel # For html in tk.
+import re
 
 # Import the statistics object dedicated to
 # passing build/train data for displaying.
@@ -145,39 +146,65 @@ def getDeviceType(self):
 
 # Class function to create the smaller window for editing labels.
 def openLabelWindow(self):  
+	# Variables used
+	edit_Label_Font = 10
+	bdSize = 2 # Border size of the lists
+
+
 	# Deactivate the 'Edit Labels' button.
 	self.editLabelButton.config(state=DISABLED)
 
 	# Create the window itself.
 	self.labelWindow = Toplevel(self)
+	self.labelWindow.minsize(700,400)
 	self.labelWindow.title('Edit Labels')
-	self.labelWindow.geometry('400x400')
+	self.labelWindow.geometry('700x400')
+
+	# Create a label frame to hold the list of tags.
+	self.listTF = LabelFrame(self.labelWindow, text='List of Tags')
+	self.listTF.place(x=10, y=5, relheight=300/400, relwidth=330/700)
 
 	# Create a label frame to hold the list of labels.
 	self.listLF = LabelFrame(self.labelWindow, text='List of Labels')
-	self.listLF.place(x=5, y=5, width=205, height=300)
+	self.listLF.place(relx=360/700, rely=5/400, relwidth=330/700, relheight=300/400)
 
 	# Create a list box of the labels gathered from the labels.txt
-	self.labelListBox = Listbox(self.listLF, bd=2, selectmode=MULTIPLE)
-	self.labelListBox.pack(side=LEFT, fill=BOTH)
+	labelScrollY = Scrollbar(self.listLF)
+	labelScrollY.pack(side=RIGHT, fill = Y)
+	labelScrollX = Scrollbar(self.listLF,orient=HORIZONTAL)
+	labelScrollX.pack(side=BOTTOM, fill = X)
+	self.labelListBox = Listbox(self.listLF, xscrollcommand=labelScrollX.set, yscrollcommand=labelScrollY.set, bd=bdSize, selectmode=SINGLE)
+	self.labelListBox.config(font=edit_Label_Font)
+	self.labelListBox.pack(side=LEFT, fill=BOTH,padx=205/700, pady=300/400, expand=True)
+	labelScrollY.config(command=self.labelListBox.yview)
+	labelScrollX.config(command=self.labelListBox.xview)
 
-	# Make a scroll bar and attach it to the list box.
-	self.labelScroll = Scrollbar(self.listLF)
-	self.labelScroll.pack(side=RIGHT, fill=BOTH)
-	self.labelListBox.config(yscrollcommand=self.labelScroll.set, font=12)
-	self.labelScroll.config(command=self.labelListBox.yview)
+	# Create a list box of the labels gathered from the tagsList.txt
+	tagScrollY = Scrollbar(self.listTF)
+	tagScrollY.pack(side=RIGHT, fill = Y)
+	tagScrollX = Scrollbar(self.listTF,orient=HORIZONTAL)
+	tagScrollX.pack(side=BOTTOM, fill = X)
+	self.tagListBox = Listbox(self.listTF, xscrollcommand=tagScrollX.set, yscrollcommand=tagScrollY.set, bd=bdSize, selectmode=SINGLE)
+	self.tagListBox.config(font=edit_Label_Font)
+	self.tagListBox.pack(side=LEFT, fill=BOTH,padx=205/700, pady=300/400, expand=True)
+	tagScrollY.config(command=self.tagListBox.yview)
+	tagScrollX.config(command=self.tagListBox.xview)
 
 	# From a class variable, insert the label in each row.
 	for label in self.labelList:
-		self.labelListBox.insert(END, label.strip())
+		self.labelListBox.insert(END, label.strip())   
+		
+	# From a class variable, insert the tag in each row.
+	for tag in self.tagsList:
+		self.tagListBox.insert(END, tag)
 
 	# Add a button for adding a label. It will call a corresponding function.
 	self.addLabelButton = Button(self.labelWindow, text='Add Label', command=lambda: addLabel(self))
-	self.addLabelButton.place(x=250, y=20, width=110, height=30)
+	self.addLabelButton.place(relx=10/700, rely=320/400, relwidth=110/700, relheight=30/400)
 
 	# Add a button for removing a label. It will also call a corresponding function.
 	self.delLabelButton = Button(self.labelWindow, text='Remove Label', command=lambda: delLabel(self))
-	self.delLabelButton.place(x=250, y=70, width=110, height=30)
+	self.delLabelButton.place(relx=580/700, rely=320/400, relwidth=110/700, relheight=30/400)
 
 	# On window exit, reactivate the button.
 	def quit_label_window():
@@ -188,29 +215,44 @@ def openLabelWindow(self):
 
 # Class function for adding a new label.
 def addLabel(self):
-	# Execute an input dialog for the user to add a new label.
-	newLabel = simpledialog.askstring('Input', 'Enter a new label:',
-		parent=self.labelWindow)
-
-	# Remove extrameous spaghetti the user inputted.
-	if newLabel:
-		newLabel = newLabel.strip()
+	newLabel_Index = self.tagListBox.curselection()
 
 	# If the user did not enter anything: do nothing, otherwise; append to file.
-	if newLabel is None:
+	if not newLabel_Index:       
 		return
 	else:
-		newLabel = '\n' + newLabel
-		if self.CLASS_NAME == '':
-			fd = open('labels.txt', 'a+')
+		newLabel = self.tagListBox.get(newLabel_Index[0])
+		fd = open('./labels.txt', 'a+')
+		if os.stat("./labels.txt").st_size == 0:
 			fd.write(newLabel)
-			fd.close()
 		else:
-			fd = open('labels.txt', 'a+')
-			fd.write(newLabel)
-			fd.close()
+			fd.write("\n"+newLabel)
+		fd.close()
+		labelSet(self)
 		getLabels(self)
 		updateListBox(self)
+
+
+#  Puts all components of label.txt into a set to sort and remove redundancy 
+def labelSet(self):
+	fd = open('./labels.txt', 'r')
+	lines = fd.readlines()
+	if lines == "":
+		pass
+	else:    
+		labels = set(lines)
+		fd.close()
+		labels = sorted(labels)
+		fd = open('./labels.txt', 'w')
+		fd.truncate(0)
+		for x in labels:
+			# Ignore empty cases            
+			if x is "\n":
+				pass              
+			else:
+				fd.write(x)
+	fd.close()
+
 
 # Function to delete labels selected.
 def delLabel(self):
@@ -230,7 +272,8 @@ def delLabel(self):
 
 	# Write over the file the remaining labels (assuming there are any).
 	if not kept_index:
-		pass
+		fd = open('labels.txt', 'w')
+		fd.write("")
 	else:
 		fd = None
 		if self.CLASS_NAME == '':
@@ -244,7 +287,7 @@ def delLabel(self):
 				label = label + "\n"
 			fd.write(label)
 		fd.close()
-
+		
 	# Get the labels from the file, and update the label list box.
 	getLabels(self)
 	updateListBox(self)
@@ -265,9 +308,18 @@ def updateListBox(self):
 
 # Opens the labels text file to update the label list.
 def getLabels(self):
-	fd = open('labels.txt', 'r')
-	self.labelList = fd.readlines()
-	fd.close() # Never forget to close your files, Thank you Dr. Park
+	# Reads in tags
+	if self.CLASS_NAME != '':
+		getTags(self)        
+		fdT = open('tagsList.txt', 'r')
+		self.tagsList = fdT.readlines()
+		fdT.close()
+	# Case where labels.txt doesn't exist
+	if os.path.exists('./labels.txt') is True:
+		#open('labels.txt', 'w')
+		fdL = open('labels.txt', 'r')
+		self.labelList = fdL.readlines()
+		fdL.close() # Never forget to close your files, Thank you Dr. Park
 
 # A function to build the neural network. If the class name == '', then there is not model
 # data selected to be built with/for.
@@ -306,6 +358,7 @@ def selectFolder(self):
 			os.chdir(temp_folder)
 			getLabels(self)
 			loadDefaultParameters(self, temp_folder[:end] + self.CLASS_NAME + '/')
+			self.editLabelButton['state'] = NORMAL
 			self.classifyButton['state'] = NORMAL
 		else:
 			messagebox.showinfo('Incorrect folder',  'Please select a proper model folder.\nExample: \'./.data/example\'')
@@ -313,6 +366,91 @@ def selectFolder(self):
 				self.classifyButton['state'] = DISABLED
 			else:
 				self.classifyButton['state'] = NORMAL
+	getTags(self)
+
+
+# Reads the tags from the rdf file and lists them inside tagsList.txt, which will be displayed to user in
+# the edit labels button to select from various exisiting tags/labels.
+def getTags(self):
+	# Check if tagsList.txt exisits, if not, create it within the current directory    
+	if os.path.exists('./tagsList.txt') is False:
+		open('tagsList.txt', 'w')    
+	
+	
+	if self.CLASS_NAME == '':
+		return
+	
+	# Gets rdf file path and gets modification dates of the rdf and tagsList files
+	rdfRoot = './' + self.CLASS_NAME + '.rdf'
+	rdfDate = time.ctime(os.path.getmtime(self.CLASS_NAME + '.rdf'))
+	tagsDate = time.ctime(os.path.getmtime('tagsList.txt'))
+	
+	# Checks to make sure tags file is empty before filling or if the rdf has been recently updated
+	if os.stat('./tagsList.txt').st_size != 0 and ((rdfDate == tagsDate) or (rdfDate < tagsDate)):       
+		return 
+    
+	# Empty the labels file in case of any deletion of tags within the labels.txt file
+	tmp = open("./labels.txt", 'w')
+	tmp.truncate(0)
+	tmp.close()
+    
+	# Reads in Tags
+	tags = open(rdfRoot, 'r', encoding = 'utf-8')
+	line = tags.readline() # Tmp string for reading thru rdf
+	tagSet = set()    # Set for all tags
+	
+	# File ends with </rdf:RDF>, but with regex, it would be changed to "rdf RDF"
+	# There's 3 cases where tags occur:
+	# (1) <dc:subject>TagName</dc:subject>
+	#
+	# (2) <dc:subject>
+	#          <z:AutomaticTag>
+	#              <rdf:value>TagName</rdf:value>
+	#          </z:AutomaticTag>
+	#     </dc:subject>
+	# 
+	# (3) <dc:subject>
+	#          <z:AutomaticTag><rdf:value>TagName</rdf:value></z:AutomaticTag>
+	#     </dc:subject>
+	
+	while line != "rdf RDF":        
+		line = regexTags(tags.readline())
+		if "dc subject" in line:
+			if len(line) == 10:                
+				line = regexTags(tags.readline())
+				if len(line) == 14: #Case (3)
+					line = regexTags(tags.readline())
+					tagSet.add(line[10:len(line)-10].capitalize())
+					line = tags.readline()
+					line = tags.readline()
+				else:   # Case(2)
+					tagSet.add(line[26:len(line)-27].capitalize())
+					line = tags.readline()
+			else:  # Case (1)             
+				tagSet.add(line[11:len(line)-11].capitalize())
+	tags.close()
+	tagSet = sorted(tagSet)    # Sorts the set
+	
+	# Add Tags to label.txt
+	tagFile = open('./tagsList.txt','w')
+	tagFile.truncate(0)    # Empties file before writing
+	for x in tagSet:
+		if len(x) != 0:
+			tagFile.write(x.capitalize())
+			tagFile.write("\n")
+	tagFile.close()
+
+
+# Uses regualr expressions to clean up any useless characters and format tags
+def regexTags(line):
+	# Removes special characters, except '-' and ','
+	tmp = re.sub('[^a-zA-Z0-9-,)(]',' ',line).strip()
+	# Checks and removes anything after ',' as the tags become repetitive with little difference
+	tmp = re.sub(',[\s\S]*$','',tmp)
+	# Checks and removes cases of '-' being the ending char
+	tmp = re.sub('[-]\Z','',tmp)
+	return tmp
+
 
 # Loads default parameters for a specific directory.
 def loadDefaultParameters(self, directory):


### PR DESCRIPTION
The edit labels button now allows the user to select from a list of read tags from the rdf model they have selected to then be put into the labels.txt file to allow them to build with. The tagsList file is a new file that will hold the list of all tags from the rdf. The rdf file is read through and regex each specific tag to allow for easier use. With the tagsList, a new list was made in app.py. The cases of missing tagsList/labels.txt was fixed by having it create them. The interface of the edit labels window was changed to display both lists of the tags and labels with the add and delete buttons below. The adds label now takes the single selected tag and adds them to the labels. txt and the delete takes the selected label and removes them from labels.txt. With each add/delete, the lists will update themselves alongside. Both lists has a horizontal and vertical scrollbar included to allow the user to view all tags/labels. Another feature was allowing the lists and buttons to scale alongside the window size of the window., but has a minimum size of 700x300. 